### PR TITLE
Notifying rooms on user leave-room and user join-room

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,7 +25,6 @@ io.on('connection', (socket) => {
 
     socket.on('chat', (message) => {
         const room = filterRooms(socket)
-
         io.to(room[0]).emit('chat', message)
         console.log(message)
     })
@@ -42,13 +41,21 @@ io.on('connection', (socket) => {
     socket.on('join-room', (room, name) => {
         socket.join(room)
         const message = name + ' has connected'
-        notifyRoom(socket, 'join-room', message)
+        notifyRoom(room, 'join-room', message)
     })
 })
 
-function notifyRoom(socket, event, message) {
-    const room = filterRooms(socket) 
-    io.to(room[0]).emit(event, message)
+function notifyRoom(context, event, message) {
+    let room = ''
+    if (typeof(context) !== 'object') {
+        // received a roomname
+        room = context
+        io.to(room).emit(event, message)
+    } else {
+        // received a socket
+        room = filterRooms(context)
+        io.to(room[0]).emit(event, message)
+    }
     console.log(message)
 }
 

--- a/server.js
+++ b/server.js
@@ -24,8 +24,7 @@ io.on('connection', (socket) => {
     console.log('Client Connected')
 
     socket.on('chat', (message) => {
-        const room = filterRooms(socket)
-        io.to(room[0]).emit('chat', message)
+        notifyRoom(filterRooms(socket), 'chat', message)
         console.log(message)
     })
 
@@ -35,7 +34,7 @@ io.on('connection', (socket) => {
     
     socket.on('leave-room', (name) => {
         const message = name + ' has disconnected'
-        notifyRoom(socket, 'leave-room', message)
+        notifyRoom(filterRooms(socket), 'leave-room', message)
     })
 
     socket.on('join-room', (room, name) => {
@@ -45,21 +44,15 @@ io.on('connection', (socket) => {
     })
 })
 
-function notifyRoom(context, event, message) {
-    let room = ''
-    if (typeof(context) !== 'object') {
-        // received a roomname
-        room = context
-        io.to(room).emit(event, message)
-    } else {
-        // received a socket
-        room = filterRooms(context)
-        io.to(room[0]).emit(event, message)
+function notifyRoom(room, event, message) {
+    if (typeof(room) !== 'string') {
+        // if the socket is passed
+        room = filterRooms(room)
     }
-    console.log(message)
+    io.to(room).emit(event, message)
 }
 
 function filterRooms(socket) { 
     return Object.keys(socket.rooms)
-        .filter(x => x !== socket.id)
+        .filter(x => x !== socket.id)[0]
 } 

--- a/server.js
+++ b/server.js
@@ -20,10 +20,9 @@ app.get('/rooms', (req, res) => {
 
 io.on('connection', (socket) => {
     console.log('Client Connected')
-
-    socket.on('chat', (message) => {
-        const room = filterRooms(socket)
-        notifyRoom(room, 'chat', message)
+    
+	socket.on('chat', (message) => {
+        notifyRoom(socket, 'chat', message)
         console.log(message)
     })
 
@@ -33,10 +32,10 @@ io.on('connection', (socket) => {
     
     socket.on('leave-room', (name) => {
         const room = filterRooms(socket)
-        const message = name + ' has disconnected'
+        const message = `${getTime()} - ${name} has disconnected`
         notifyRoom(room, 'leave-room', message)
-        console.log(message + ' from ' + room)
-        
+		console.log(`${message} from ${room}`) 
+ 
         socket.leave(room, (err) => {
             if (err) {
                 console.log(err)
@@ -46,9 +45,9 @@ io.on('connection', (socket) => {
 
     socket.on('join-room', (room, name) => {
         socket.join(room)
-        const message = name + ' has connected'
+        const message =  `${getTime()} - ${name} has connected`
         notifyRoom(room, 'join-room', message)
-        console.log(message + ' to ' + room)
+        console.log(`${message} to ${room}`)
     })
 })
 
@@ -64,3 +63,8 @@ function filterRooms(socket) {
     return Object.keys(socket.rooms)
         .filter(x => x !== socket.id)[0]
 } 
+
+function getTime() {
+	let d = new Date()
+	return `${(d.getHours() >= 12 ? d.getHours() - 12 : d.getHours())}:${d.getMinutes()}`
+}

--- a/server.js
+++ b/server.js
@@ -11,6 +11,8 @@ server.listen(port, () => {
 
 app.get('/rooms', (req, res) => {
     const rooms = io.sockets.adapter.rooms
+    console.log(io.sockets.adapter.rooms)
+
     const chatRooms = Object.keys(rooms)
         .filter(room => Object.keys(rooms[room].sockets)[0] !== room)
         .map(room => ({ name: room, size: rooms[room].length }))
@@ -22,8 +24,7 @@ io.on('connection', (socket) => {
     console.log('Client Connected')
 
     socket.on('chat', (message) => {
-        const room = Object.keys(socket.rooms)
-            .filter(x => x !== socket.id)
+        const room = filterRooms(socket)
 
         io.to(room[0]).emit('chat', message)
         console.log(message)
@@ -33,8 +34,11 @@ io.on('connection', (socket) => {
         // private message received
     })
 
-    socket.on('disconnect', () => {
-        io.emit('client disconnected')
+    socket.on('user-disconnect', (name) => {
+        const room = filterRooms(socket)
+        const message = name + ' has disconnected'
+        io.to(room[0]).emit('user-disconnect', message)
+        console.log(message)
     })
 
     socket.on('create', (room) => {
@@ -42,3 +46,7 @@ io.on('connection', (socket) => {
     })
 })
 
+function filterRooms(socket) { 
+    return Object.keys(socket.rooms)
+        .filter(x => x !== socket.id)
+} 

--- a/server.js
+++ b/server.js
@@ -22,7 +22,8 @@ io.on('connection', (socket) => {
     console.log('Client Connected')
 
     socket.on('chat', (message) => {
-        notifyRoom(filterRooms(socket), 'chat', message)
+        const room = filterRooms(socket)
+        notifyRoom(room, 'chat', message)
         console.log(message)
     })
 
@@ -31,14 +32,23 @@ io.on('connection', (socket) => {
     })
     
     socket.on('leave-room', (name) => {
+        const room = filterRooms(socket)
         const message = name + ' has disconnected'
-        notifyRoom(filterRooms(socket), 'leave-room', message)
+        notifyRoom(room, 'leave-room', message)
+        console.log(message + ' from ' + room)
+        
+        socket.leave(room, (err) => {
+            if (err) {
+                console.log(err)
+            }
+        })
     })
 
     socket.on('join-room', (room, name) => {
         socket.join(room)
         const message = name + ' has connected'
         notifyRoom(room, 'join-room', message)
+        console.log(message + ' to ' + room)
     })
 })
 

--- a/server.js
+++ b/server.js
@@ -11,8 +11,6 @@ server.listen(port, () => {
 
 app.get('/rooms', (req, res) => {
     const rooms = io.sockets.adapter.rooms
-    console.log(io.sockets.adapter.rooms)
-
     const chatRooms = Object.keys(rooms)
         .filter(room => Object.keys(rooms[room].sockets)[0] !== room)
         .map(room => ({ name: room, size: rooms[room].length }))

--- a/server.js
+++ b/server.js
@@ -33,18 +33,24 @@ io.on('connection', (socket) => {
     socket.on('private', (sender, message) => {
         // private message received
     })
-
-    socket.on('user-disconnect', (name) => {
-        const room = filterRooms(socket)
+    
+    socket.on('leave-room', (name) => {
         const message = name + ' has disconnected'
-        io.to(room[0]).emit('user-disconnect', message)
-        console.log(message)
+        notifyRoom(socket, 'leave-room', message)
     })
 
-    socket.on('create', (room) => {
+    socket.on('join-room', (room, name) => {
         socket.join(room)
+        const message = name + ' has connected'
+        notifyRoom(socket, 'join-room', message)
     })
 })
+
+function notifyRoom(socket, event, message) {
+    const room = filterRooms(socket) 
+    io.to(room[0]).emit(event, message)
+    console.log(message)
+}
 
 function filterRooms(socket) { 
     return Object.keys(socket.rooms)


### PR DESCRIPTION
## Changes in Sockets
```
create -> join-room
disconnect -> leave-room
```
- Client must send their username on join-room
- Client must send their username on leave-room
- Changed 'create' to 'join-room'


```
socket.on('create', (room) => ...
socket.on('disconnect', () => ...
```
changed to
```
socket.on('join-room', (room, name) => ...
socket.on('leave-room', (name) => ...
```

## TODO
- [x] Add an event to switch rooms with the header of
```
socket.on('switch-room', (room1, room2, name) => ...
```